### PR TITLE
Added API Events Controller

### DIFF
--- a/app/controllers/api/events_controller.rb
+++ b/app/controllers/api/events_controller.rb
@@ -1,5 +1,7 @@
 class API::EventsController < ApplicationController
 
+  skip_before_action :verify_authenticity_token
+  
   before_filter :set_access_control_headers
 
   def set_access_control_headers

--- a/app/controllers/api/events_controller.rb
+++ b/app/controllers/api/events_controller.rb
@@ -1,0 +1,39 @@
+class API::EventsController < ApplicationController
+
+  before_filter :set_access_control_headers
+
+  def set_access_control_headers
+# #1
+    headers['Access-Control-Allow-Origin'] = '*'
+# #2
+    headers['Access-Control-Allow-Methods'] = 'POST, GET, OPTIONS'
+# #3
+    headers['Access-Control-Allow-Headers'] = 'Content-Type'
+  end
+
+  def create
+    registered_application = RegisteredApplication.find_by(url: request.env['HTTP_ORIGIN'])
+
+    if registered_application.nil?
+      render json: { error: "missing valid registered application URL" }, status: :unprocessable_entity
+    else
+      @event = registered_application.events.build( event_params )
+        if @event.save
+          render json: @event, status: :created
+        else
+          render json: { error: "missing event name" }, status: :unprocessable_entity
+        end
+    end
+
+  end
+
+  def preflight
+    head 200
+  end
+
+  private
+
+  def event_params
+    params.require(:event).permit(:name)
+  end
+end

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -1,2 +1,9 @@
 class UserMailer < ApplicationMailer
+  default from: 'notifications@example.com'
+
+  def welcome_email(user)
+    @user = user
+    @url  = 'http://example.com/login'
+    mail(to: @user.email, subject: 'Welcome to My Blocmetrics!')
+  end
 end

--- a/config/initializers/inflections.rb
+++ b/config/initializers/inflections.rb
@@ -14,3 +14,6 @@
 # ActiveSupport::Inflector.inflections(:en) do |inflect|
 #   inflect.acronym 'RESTful'
 # end
+ActiveSupport::Inflector.inflections(:en) do |inflect|
+  inflect.acronym 'API'
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,12 @@ Rails.application.routes.draw do
 
   devise_for :users
   resources :users, only: [:show]
+
+  namespace :api, defaults: { format: :json } do
+    match '/events', to: 'events#preflight', via: [:options]
+    resources :events, only: [:create]
+  end
+
   root to: 'home#index'
   get 'home/index'
 


### PR DESCRIPTION
After adding the code in the assignment and running the provided curl:

'curl -v -H "Accept: application/json" -H "Origin: http://registered_application.com" -H "Content-Type: application/json" -X POST -d '{"name":"foobar"}'  http://localhost:3000/api/events'

The Foobar event is not created based on running 'Event.last' in the rails console. And I'm receiving what I believe is an error message (though rather long and unfamiliar to me at this point) of an internal server error (see below). However, so much code follows it, I believe that it's running and not a complete error, so I'm unsure as to why Foobar is not being added as an event. 

'* upload completely sent off: 17 out of 17 bytes
< HTTP/1.1 500 Internal Server Error 
< Content-Type: text/html; charset=utf-8
< Content-Length: 99344
< X-Web-Console-Session-Id: c33a5377a4d31d6492f699492cfb0aae
< X-Web-Console-Mount-Point: /__web_console
< X-Request-Id: 051c7475-5329-4eb3-ad78-682ea37d9b9d
< X-Runtime: 0.387976
< Server: WEBrick/1.3.1 (Ruby/2.2.1/2015-02-26)
< Date: Sun, 25 Sep 2016 21:03:24 GMT
< Connection: Keep-Alive'
